### PR TITLE
feat: refactor(phase-4): shared UI primitives

### DIFF
--- a/src/components/content/TableOfContents.astro
+++ b/src/components/content/TableOfContents.astro
@@ -1,4 +1,6 @@
 ---
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
+
 interface Props {
 	headings: { depth: number; slug: string; text: string }[];
 }
@@ -15,20 +17,7 @@ const mainHeadings = headings.filter((heading) => heading.depth <= 3);
         href="/writing"
         class="flex items-center gap-1.5 text-sm mb-6 text-foreground-2 hover:text-foreground transition-colors duration-200"
     >
-        <svg
-            width="16"
-            height="16"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            viewBox="0 0 24 24"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            xmlns="http://www.w3.org/2000/svg"
-            class="rotate-180"
-        >
-            <path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6"></path>
-        </svg>
+        <ArrowIcon size={16} class="rotate-180" />
         <span>writing</span>
     </a>
 
@@ -54,20 +43,7 @@ const mainHeadings = headings.filter((heading) => heading.depth <= 3);
         href="/writing"
         class="flex items-center gap-1.5 text-sm mb-6 text-foreground-2 hover:text-foreground transition-colors duration-200"
     >
-        <svg
-            width="16"
-            height="16"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            viewBox="0 0 24 24"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            xmlns="http://www.w3.org/2000/svg"
-            class="rotate-180"
-        >
-            <path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6"></path>
-        </svg>
+        <ArrowIcon size={16} class="rotate-180" />
         <span>writing</span>
     </a>
 </nav>

--- a/src/components/home/AchievementRow.astro
+++ b/src/components/home/AchievementRow.astro
@@ -1,5 +1,6 @@
 ---
 import Flag from "../brand/Flag.astro";
+import ListRow from "../ui/ListRow.astro";
 
 interface Props {
 	item: {
@@ -17,26 +18,28 @@ interface Props {
 const { item, showYear } = Astro.props;
 ---
 
-<div class="group -mx-3 flex items-baseline gap-4 border-b border-ui px-3 py-3 transition-colors hover:bg-background-2">
-	<span class="w-12 shrink-0 text-sm tabular-nums text-foreground-3">
+<ListRow>
+	<span slot="leading" class="w-12 text-sm tabular-nums text-foreground-3">
 		{showYear ? item.year : ""}
 	</span>
-	<span class="w-36 shrink-0 text-sm font-medium text-foreground">{item.achievement}</span>
-	<span class="flex-1 text-sm">
-		{item.eventUrl ? (
-			<a
-				href={item.eventUrl}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-foreground-2 underline decoration-ui/50 transition-colors hover:text-foreground hover:decoration-ui"
-			>
-				{item.event}
-			</a>
-		) : (
-			<span class="text-foreground-2">{item.event}</span>
-		)}
-	</span>
-	<span class="hidden shrink-0 text-sm sm:block">
+	<div class="flex items-baseline gap-4 text-sm">
+		<span class="w-36 shrink-0 font-medium text-foreground">{item.achievement}</span>
+		<span class="min-w-0 flex-1">
+			{item.eventUrl ? (
+				<a
+					href={item.eventUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="text-foreground-2 underline decoration-ui/50 transition-colors hover:text-foreground hover:decoration-ui"
+				>
+					{item.event}
+				</a>
+			) : (
+				<span class="text-foreground-2">{item.event}</span>
+			)}
+		</span>
+	</div>
+	<span slot="trailing" class="hidden text-sm sm:block">
 		{item.project && item.projectUrl ? (
 			<a
 				href={item.projectUrl}
@@ -50,11 +53,11 @@ const { item, showYear } = Astro.props;
 			<span class="text-foreground-3">{item.project}</span>
 		) : null}
 	</span>
-	<span class="shrink-0">
+	<span slot="trailing" class="shrink-0">
 		{item.scope === "global" && <Flag country="globe" width={16} height={16} class="text-foreground-2" />}
 		{item.scope === "pe" && <Flag country="pe" width={16} height={16} />}
 		{item.scope === "cl" && <Flag country="cl" width={16} height={16} />}
 		{item.scope === "co" && <Flag country="co" width={16} height={16} />}
 		{item.scope === "br" && <Flag country="br" width={16} height={16} />}
 	</span>
-</div>
+</ListRow>

--- a/src/components/home/FeaturedProjectRow.astro
+++ b/src/components/home/FeaturedProjectRow.astro
@@ -1,6 +1,7 @@
 ---
 import BrandIcon from "../brand/BrandIcon.astro";
 import type { BrandName } from "../brand/registry";
+import ListRow from "../ui/ListRow.astro";
 
 interface Props {
 	project: {
@@ -14,29 +15,10 @@ interface Props {
 const { project } = Astro.props;
 ---
 
-<a
-	href={project.url}
-	target="_blank"
-	rel="noopener noreferrer"
-	class="group -mx-3 flex items-center gap-4 border-b border-ui px-3 py-3 transition-colors hover:bg-background-2"
->
-	<span class="flex h-6 w-6 shrink-0 items-center justify-center">
+<ListRow href={project.url} external={true} showArrow={true}>
+	<span slot="leading" class="flex h-6 w-6 self-center items-center justify-center">
 		<BrandIcon name={project.icon} width={20} height={20} class="text-foreground" />
 	</span>
-	<span class="flex-1 text-sm font-medium text-foreground">{project.name}</span>
-	<span class="hidden text-sm text-foreground-3 sm:block">{project.description}</span>
-	<svg
-		width="14"
-		height="14"
-		fill="none"
-		stroke="currentColor"
-		stroke-width="1.5"
-		viewBox="0 0 24 24"
-		stroke-linecap="round"
-		stroke-linejoin="round"
-		xmlns="http://www.w3.org/2000/svg"
-		class="shrink-0 text-foreground-3 transition-transform group-hover:translate-x-0.5"
-	>
-		<path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6" />
-	</svg>
-</a>
+	<span class="self-center text-sm font-medium text-foreground">{project.name}</span>
+	<span slot="trailing" class="hidden self-center text-sm text-foreground-3 sm:block">{project.description}</span>
+</ListRow>

--- a/src/components/ui/AchievementCard.astro
+++ b/src/components/ui/AchievementCard.astro
@@ -1,15 +1,7 @@
 ---
 import EmbedContainer from "@/content/EmbedContainer.astro";
+import type { ColorName } from "@/lib/colors";
 import Card from "./Card.astro";
-
-type ColorName =
-	| "blue"
-	| "teal"
-	| "yellow"
-	| "cyan"
-	| "purple"
-	| "magenta"
-	| "orange";
 
 interface Props {
 	title: string;

--- a/src/components/ui/ArrowIcon.astro
+++ b/src/components/ui/ArrowIcon.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+	size?: number;
+	class?: string;
+}
+
+const { size = 14, class: className } = Astro.props;
+---
+
+<svg
+	width={size}
+	height={size}
+	fill="none"
+	stroke="currentColor"
+	stroke-width="1.5"
+	viewBox="0 0 24 24"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	xmlns="http://www.w3.org/2000/svg"
+	class={className}
+>
+	<path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6" />
+</svg>

--- a/src/components/ui/BlogCard.astro
+++ b/src/components/ui/BlogCard.astro
@@ -1,17 +1,9 @@
 ---
 import CrafterIcon from "@/assets/svgs/crafter.svg";
 import ViewCounter from "@/components/blog/ViewCounter";
+import type { ColorName } from "@/lib/colors";
 import BrandIcon from "../brand/BrandIcon.astro";
 import Card from "./Card.astro";
-
-type ColorName =
-	| "blue"
-	| "teal"
-	| "yellow"
-	| "cyan"
-	| "purple"
-	| "magenta"
-	| "orange";
 
 interface Props {
 	title: string;

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -1,12 +1,5 @@
 ---
-type ColorName =
-	| "blue"
-	| "teal"
-	| "yellow"
-	| "cyan"
-	| "purple"
-	| "magenta"
-	| "orange";
+import { type ColorName, colorMap } from "@/lib/colors";
 
 interface Props {
 	href?: string;
@@ -25,51 +18,6 @@ const {
 	transitionName,
 	padding = "p-3",
 } = Astro.props;
-
-const colorMap = {
-	blue: {
-		border: "hover:border-blue/30",
-		text: "group-hover:text-blue",
-		gradient: "from-blue/[0.05]",
-		shine: "via-blue/10",
-	},
-	teal: {
-		border: "hover:border-teal/30",
-		text: "group-hover:text-teal",
-		gradient: "from-teal/[0.05]",
-		shine: "via-teal/10",
-	},
-	yellow: {
-		border: "hover:border-yellow/30",
-		text: "group-hover:text-yellow",
-		gradient: "from-yellow/[0.05]",
-		shine: "via-yellow/10",
-	},
-	cyan: {
-		border: "hover:border-cyan/30",
-		text: "group-hover:text-cyan",
-		gradient: "from-cyan/[0.05]",
-		shine: "via-cyan/10",
-	},
-	purple: {
-		border: "hover:border-purple/30",
-		text: "group-hover:text-purple",
-		gradient: "from-purple/[0.05]",
-		shine: "via-purple/10",
-	},
-	magenta: {
-		border: "hover:border-magenta/30",
-		text: "group-hover:text-magenta",
-		gradient: "from-magenta/[0.05]",
-		shine: "via-magenta/10",
-	},
-	orange: {
-		border: "hover:border-orange/30",
-		text: "group-hover:text-orange",
-		gradient: "from-orange/[0.05]",
-		shine: "via-orange/10",
-	},
-} as const;
 
 const Component = href ? "a" : "div";
 const styles = colorMap[color];

--- a/src/components/ui/CardIcon.astro
+++ b/src/components/ui/CardIcon.astro
@@ -1,12 +1,5 @@
 ---
-type ColorName =
-	| "blue"
-	| "teal"
-	| "yellow"
-	| "cyan"
-	| "purple"
-	| "magenta"
-	| "orange";
+import type { ColorName } from "@/lib/colors";
 
 interface Props {
 	color?: ColorName;

--- a/src/components/ui/ListRow.astro
+++ b/src/components/ui/ListRow.astro
@@ -1,0 +1,34 @@
+---
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
+
+interface Props {
+	href?: string;
+	external?: boolean;
+	hover?: boolean;
+	showArrow?: boolean;
+}
+
+const { href, external = false, hover = true, showArrow = false } = Astro.props;
+const Component = href ? "a" : "div";
+---
+
+<Component
+	href={href}
+	target={external ? "_blank" : undefined}
+	rel={external ? "noopener noreferrer" : undefined}
+	class:list={[
+		"group -mx-3 flex items-baseline gap-4 border-b border-ui px-3 py-3 transition-colors",
+		hover && "hover:bg-background-2",
+	]}
+>
+	<div class="shrink-0">
+		<slot name="leading" />
+	</div>
+	<div class="min-w-0 flex-1">
+		<slot />
+	</div>
+	<div class="flex shrink-0 items-baseline gap-4">
+		<slot name="trailing" />
+		{showArrow && <ArrowIcon class="shrink-0 text-foreground-3 transition-transform group-hover:translate-x-0.5" />}
+	</div>
+</Component>

--- a/src/components/ui/PresentCard.astro
+++ b/src/components/ui/PresentCard.astro
@@ -1,15 +1,8 @@
 ---
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
+import type { ColorName } from "@/lib/colors";
 import Card from "./Card.astro";
 import CardIcon from "./CardIcon.astro";
-
-type ColorName =
-	| "blue"
-	| "teal"
-	| "yellow"
-	| "cyan"
-	| "purple"
-	| "magenta"
-	| "orange";
 
 interface Props {
 	title: string;
@@ -57,9 +50,7 @@ const {
           >
             {title}
           </h3>
-          <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" class="text-foreground-3 group-hover:translate-x-1 transition-transform">
-            <path d='M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6'/>
-          </svg>
+          <ArrowIcon size={16} class="text-foreground-3 transition-transform group-hover:translate-x-1" />
         </div>
       )}
       {!href && (

--- a/src/components/ui/ProjectCard.astro
+++ b/src/components/ui/ProjectCard.astro
@@ -1,15 +1,8 @@
 ---
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
+import type { ColorName } from "@/lib/colors";
 import Card from "./Card.astro";
 import CardIcon from "./CardIcon.astro";
-
-type ColorName =
-	| "blue"
-	| "teal"
-	| "yellow"
-	| "cyan"
-	| "purple"
-	| "magenta"
-	| "orange";
 
 interface Props {
 	title: string;
@@ -54,9 +47,7 @@ const {
         >
           {title}
         </h3>
-        <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" class="text-foreground-3 group-hover:translate-x-1 transition-transform">
-          <path d='M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6'/>
-        </svg>
+        <ArrowIcon size={16} class="text-foreground-3 transition-transform group-hover:translate-x-1" />
       </div>
       <p class="text-sm text-foreground-2 !m-0">
         {description}

--- a/src/components/ui/SectionLink.astro
+++ b/src/components/ui/SectionLink.astro
@@ -1,0 +1,22 @@
+---
+import SectionHeader from "@/components/layout/SectionHeader.astro";
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
+
+interface Props {
+	title: string;
+	href: string;
+	viewAllLabel?: string;
+}
+
+const { title, href, viewAllLabel = "view all" } = Astro.props;
+---
+
+<div class="mb-4 flex items-center justify-between">
+	<SectionHeader title={title} className="mb-0" />
+	<a href={href} class="group text-xs text-foreground-3 transition-colors duration-200 hover:text-foreground-2">
+		<span class="flex items-center gap-1">
+			<span>{viewAllLabel}</span>
+			<ArrowIcon size={10} />
+		</span>
+	</a>
+</div>

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,61 @@
+export type ColorName =
+	| "blue"
+	| "teal"
+	| "yellow"
+	| "cyan"
+	| "purple"
+	| "magenta"
+	| "orange";
+
+export const colorMap = {
+	blue: {
+		border: "hover:border-blue/30",
+		text: "group-hover:text-blue",
+		gradient: "from-blue/[0.05]",
+		shine: "via-blue/10",
+	},
+	teal: {
+		border: "hover:border-teal/30",
+		text: "group-hover:text-teal",
+		gradient: "from-teal/[0.05]",
+		shine: "via-teal/10",
+	},
+	yellow: {
+		border: "hover:border-yellow/30",
+		text: "group-hover:text-yellow",
+		gradient: "from-yellow/[0.05]",
+		shine: "via-yellow/10",
+	},
+	cyan: {
+		border: "hover:border-cyan/30",
+		text: "group-hover:text-cyan",
+		gradient: "from-cyan/[0.05]",
+		shine: "via-cyan/10",
+	},
+	purple: {
+		border: "hover:border-purple/30",
+		text: "group-hover:text-purple",
+		gradient: "from-purple/[0.05]",
+		shine: "via-purple/10",
+	},
+	magenta: {
+		border: "hover:border-magenta/30",
+		text: "group-hover:text-magenta",
+		gradient: "from-magenta/[0.05]",
+		shine: "via-magenta/10",
+	},
+	orange: {
+		border: "hover:border-orange/30",
+		text: "group-hover:text-orange",
+		gradient: "from-orange/[0.05]",
+		shine: "via-orange/10",
+	},
+} as const satisfies Record<
+	ColorName,
+	{
+		border: string;
+		text: string;
+		gradient: string;
+		shine: string;
+	}
+>;

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -5,6 +5,7 @@ import ViewCounter from "@/components/blog/ViewCounter";
 import Link from "@/components/content/Link.astro";
 import Quote from "@/components/content/Quote.astro";
 import TableOfContents from "@/components/content/TableOfContents.astro";
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
 import { isPostVisible } from "@/config/blog";
 import { getReadingTime } from "@/config/reading-time";
 import Layout from "@/layouts/Layout.astro";
@@ -221,9 +222,7 @@ const {
                     class="group block p-4 border border-ui rounded-lg hover:border-foreground-3 hover:bg-background-2 transition-all"
                 >
                     <span class="text-xs text-foreground-3 uppercase tracking-wider flex items-center gap-1">
-                        <svg width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" class="rotate-180">
-                            <path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6" stroke-linecap="round" stroke-linejoin="round"/>
-                        </svg>
+                        <ArrowIcon size={12} class="rotate-180" />
                         Previous
                     </span>
                     <h4 class="mt-2 text-sm text-foreground-2 group-hover:text-foreground transition-colors leading-snug line-clamp-2">
@@ -238,9 +237,7 @@ const {
                 >
                     <span class="text-xs text-foreground-3 uppercase tracking-wider flex items-center gap-1 md:justify-end">
                         Next
-                        <svg width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                            <path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6" stroke-linecap="round" stroke-linejoin="round"/>
-                        </svg>
+                        <ArrowIcon size={12} />
                     </span>
                     <h4 class="mt-2 text-sm text-foreground-2 group-hover:text-foreground transition-colors leading-snug line-clamp-2">
                         {nextPost.data.title}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,8 @@ import HeroSection from "@/components/layout/HeroSection.astro";
 import PageLayout from "@/components/layout/PageLayout.astro";
 import SectionHeader from "@/components/layout/SectionHeader.astro";
 import NewsletterSection from "@/components/newsletter/NewsletterSection.astro";
+import ListRow from "@/components/ui/ListRow.astro";
+import SectionLink from "@/components/ui/SectionLink.astro";
 import { isPostListable } from "@/config/blog";
 import { ogUrl, siteConfig } from "@/config/site";
 import { achievements } from "@/data/achievements";
@@ -57,54 +59,38 @@ const formatDate = (date: Date) =>
 		<HeroSection name={siteConfig.name} title={siteConfig.hero.title} />
 
 		<section class="w-full">
-			<div class="mb-4 flex items-center justify-between">
-				<SectionHeader title="Projects" className="mb-0" />
-				<a href="/projects" class="group text-xs text-foreground-3 transition-colors duration-200 hover:text-foreground-2">
-					<span class="flex items-center gap-1">
-						<span>view all</span>
-						<svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6"></path></svg>
-					</span>
-				</a>
-			</div>
+			<SectionLink title="Projects" href="/projects" />
 			<div class="space-y-0">
 				{featuredProjects.map((project) => <FeaturedProjectRow project={project} />)}
 			</div>
 		</section>
 
 		<section class="w-full">
-			<div class="mb-4 flex items-center justify-between">
-				<SectionHeader title="Writing" className="mb-0" />
-				<a href="/writing" class="group text-xs text-foreground-3 transition-colors duration-200 hover:text-foreground-2">
-					<span class="flex items-center gap-1">
-						<span>view all</span>
-						<svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><path d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6"></path></svg>
-					</span>
-				</a>
-			</div>
+			<SectionLink title="Writing" href="/writing" />
 			<div class="space-y-0">
 				{years.map((year) => postsByYear[year].map((post, index) => {
 					const isPremiere = post.data.status === "premiere" && new Date() < post.data.pubDate;
 					return isPremiere ? (
-						<div class="group -mx-3 flex items-baseline gap-4 border-b border-ui px-3 py-3 transition-colors cursor-default">
-							<span class="w-12 shrink-0 text-sm tabular-nums text-foreground-3">{index === 0 ? year : ""}</span>
-							<span class="flex-1 text-sm font-medium text-foreground-3">
+						<ListRow hover={false}>
+							<span slot="leading" class="w-12 text-sm tabular-nums text-foreground-3">{index === 0 ? year : ""}</span>
+							<span class="text-sm font-medium text-foreground-3">
 								{post.data.title}
 								<span class="ml-2 rounded border border-ui px-1.5 py-0.5 text-xs font-normal text-foreground-3">Premiere</span>
 							</span>
-							<PremiereCountdown pubDate={post.data.pubDate.toISOString()} client:load />
-						</div>
+							<PremiereCountdown slot="trailing" pubDate={post.data.pubDate.toISOString()} client:load />
+						</ListRow>
 					) : (
-						<a href={`/blog/${post.slug}`} class="group -mx-3 flex items-baseline gap-4 border-b border-ui px-3 py-3 transition-colors hover:bg-background-2">
-							<span class="w-12 shrink-0 text-sm tabular-nums text-foreground-3">{index === 0 ? year : ""}</span>
-							<span class="flex-1 text-sm font-medium text-foreground group-hover:text-foreground">
+						<ListRow href={`/blog/${post.slug}`}>
+							<span slot="leading" class="w-12 text-sm tabular-nums text-foreground-3">{index === 0 ? year : ""}</span>
+							<span class="text-sm font-medium text-foreground group-hover:text-foreground">
 								{post.data.title}
 								{isNewest(post.slug) ? (
 									<span class="ml-2 rounded bg-ui px-1.5 py-0.5 text-xs font-normal text-foreground-2">Newest</span>
 								) : null}
 							</span>
-							<ViewCounter slug={post.slug} client:load className="shrink-0 text-xs tabular-nums text-foreground-3" />
-							<span class="shrink-0 text-sm tabular-nums text-foreground-3">{formatDate(post.data.pubDate)}</span>
-						</a>
+							<ViewCounter slot="trailing" slug={post.slug} client:load className="text-xs tabular-nums text-foreground-3" />
+							<span slot="trailing" class="text-sm tabular-nums text-foreground-3">{formatDate(post.data.pubDate)}</span>
+						</ListRow>
 					);
 				}))}
 				{recentPosts.length === 0 && <div class="py-12 text-center"><p class="text-foreground-2">More stories coming soon</p></div>}

--- a/src/pages/til/index.astro
+++ b/src/pages/til/index.astro
@@ -4,6 +4,7 @@ import Link from "@/components/content/Link.astro";
 import PageLayout from "@/components/layout/PageLayout.astro";
 import TilFilters from "@/components/til/TilFilters.tsx";
 import TilShareLink from "@/components/til/TilShareLink.tsx";
+import ArrowIcon from "@/components/ui/ArrowIcon.astro";
 import Layout from "@/layouts/Layout.astro";
 
 const tils = await getCollection("til", ({ data }) => {
@@ -111,20 +112,7 @@ const formatDateShort = (date: Date) => {
 								class="inline-flex items-center gap-1 text-sm text-foreground-3 hover:text-foreground transition-colors mt-3"
 							>
 								Learn more
-								<svg
-									width="12"
-									height="12"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.5"
-									viewBox="0 0 24 24"
-								>
-									<path
-										d="M4.5 12h15m0 0-5.625-6m5.625 6-5.625 6"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									/>
-								</svg>
+								<ArrowIcon size={12} />
 							</a>
 						)}
 					</article>


### PR DESCRIPTION
## Summary
- extract shared `ArrowIcon`, `SectionLink`, `ListRow`, and `colors` primitives
- replace repeated homepage section header and row markup with the new primitives
- swap remaining shared chevron usages to `ArrowIcon` and centralize `ColorName`

## Verification
- bunx biome check src
- bun run build
- wc -l src/pages/index.astro
- rg -c 'M4\\.5 12h15' src

Closes #3